### PR TITLE
Fix uglify in production config.

### DIFF
--- a/src/config/webpack.config.prod.js
+++ b/src/config/webpack.config.prod.js
@@ -3,12 +3,12 @@ const webpack = require('webpack');
 const { SRC } = require('./paths');
 const defaultConfig = require('./webpack.common');
 
-defaultConfig.plugins.concat([
-  new webpack.optimize.UglifyJsPlugin({ minimize: true })
-]);
 
 const prodConfig = Object.assign({}, defaultConfig, {
-  entry: { app: [`${SRC}/styles/app.scss`, `${SRC}/client-entry.js`] }
+  entry: { app: [`${SRC}/styles/app.scss`, `${SRC}/client-entry.js`] },
+  plugins: defaultConfig.plugins.concat([
+    new webpack.optimize.UglifyJsPlugin({ minimize: true })
+  ])
 });
 
 module.exports = prodConfig;


### PR DESCRIPTION
`concat` creates a _new_ array, which was not used previously, resulting in UglifyJS not being enabled in production.

In my project, I use webpack-isomorphic-tools, so not modifying the common configuration object but creating a new instance is required, so I prefer this approach instead of manipulating the array with `push`.